### PR TITLE
Add support for arrays of tags.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,10 @@ function plugin(opts) {
       // If we have tag data for this file then turn it into an array of
       // individual tags where each tag has been sanitized.
       if (data[opts.handle]) {
-        data[opts.handle] = data[opts.handle].split(',').map(trimSafeTag);
+        if (typeof data[opts.handle] === 'string') {
+          data[opts.handle] = data[opts.handle].split(",");
+        }
+        data[opts.handle] = data[opts.handle].map(trimSafeTag);
 
         // Add each tag to our overall tagList.
         data[opts.handle].forEach(function(tag) {

--- a/test/fixtures/expected/no-pagination/topics/hello.html
+++ b/test/fixtures/expected/no-pagination/topics/hello.html
@@ -1,8 +1,10 @@
 <h1>Posts for hello</h1>
 <ul>
-	<li><small>02/03/2014</small> test</li>
-
 	<li><small>07/02/2014</small> test page 2</li>
+
+	<li><small>07/01/2014</small> test json</li>
+
+	<li><small>02/03/2014</small> test</li>
 
 	<li><small>02/02/2014</small> about</li>
 </ul>

--- a/test/fixtures/expected/no-pagination/topics/tag.html
+++ b/test/fixtures/expected/no-pagination/topics/tag.html
@@ -1,6 +1,8 @@
 <h1>Posts for tag</h1>
 <ul>
-	<li><small>02/03/2014</small> test</li>
-
 	<li><small>07/02/2014</small> test page 2</li>
+
+	<li><small>07/01/2014</small> test json</li>
+
+	<li><small>02/03/2014</small> test</li>
 </ul>

--- a/test/fixtures/expected/pagination/topics/hello/2/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/2/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
-	<li><small>07/02/2014</small> test page 2</li>
+	<li><small>07/01/2014</small> test json</li>
 </ul>

--- a/test/fixtures/expected/pagination/topics/hello/4/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/4/index.html
@@ -1,0 +1,4 @@
+<h1>Posts for hello</h1>
+<ul>
+	<li><small>02/02/2014</small> about</li>
+</ul>

--- a/test/fixtures/expected/pagination/topics/hello/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
-	<li><small>02/03/2014</small> test</li>
+	<li><small>07/02/2014</small> test page 2</li>
 </ul>

--- a/test/fixtures/expected/pagination/topics/tag/2/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/2/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for tag</h1>
 <ul>
-	<li><small>07/02/2014</small> test page 2</li>
+	<li><small>07/01/2014</small> test json</li>
 </ul>

--- a/test/fixtures/expected/pagination/topics/tag/3/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/3/index.html
@@ -1,4 +1,4 @@
-<h1>Posts for hello</h1>
+<h1>Posts for tag</h1>
 <ul>
 	<li><small>02/03/2014</small> test</li>
 </ul>

--- a/test/fixtures/expected/pagination/topics/tag/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for tag</h1>
 <ul>
-	<li><small>02/03/2014</small> test</li>
+	<li><small>07/02/2014</small> test page 2</li>
 </ul>

--- a/test/fixtures/src/json.html
+++ b/test/fixtures/src/json.html
@@ -1,0 +1,10 @@
+---
+{
+  "title": "test json",
+  "tags": ["hello", "tag"],
+  "date": "2014-01-07T17:39:06.157Z"
+}
+---
+
+Lorem ipsum dolor sit amet, <em>consectetur adipisicing<em> elit. Deserunt odio provident at, cum, quasi perferendis suscipit aliquam dolores alias sequi vel ullam! Corrupti libero aliquid, tempora esse cupiditate impedit consectetur.
+

--- a/test/index.js
+++ b/test/index.js
@@ -13,8 +13,8 @@ Handlebars.registerHelper('dateFormat', function(context, format) {
 
 describe('metalsmith-tags', function() {
 
-	it('should modify comma separated tags into dehumanized array', function(done) {
-		Metalsmith('test/fixtures')
+  it('should modify comma separated tags into dehumanized array', function(done) {
+    Metalsmith('test/fixtures')
       .use(tags({
         handle: 'tags',
         path:'topics'


### PR DESCRIPTION
This just expands the supported input formats to support actual arrays instead of just comma separated strings.

We have a system that is generating tags in array format, and since this plugin converts the csv to an array already, it seemed like a natural fit.