### PR TITLE
Add metadata to main data object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,11 +50,17 @@ function plugin(opts) {
       }
     }
 
+    // Add to metalsmith.data for access outside of the tag files.
+    if (!metalsmith.data.tags) {
+      metalsmith.data.tags = {};
+    }
+
     for (var tag in tagList) {
         var posts = tagList[tag].sort(sortBy);
         if ( opts.reverse ) {
           posts.reverse();
         }
+        metalsmith.data.tags[tag] = posts;
         files[opts.path + '/' + tag + '.html'] = {
                template: opts.template,
                mode: '0644',

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,25 @@ describe('metalsmith-tags', function(){
       });
   });
 
+  it('should create a tags property to metalsmith.data', function(done) {
+    var tagList;
+
+    Metalsmith('test/fixtures')
+      .use(tags({
+        handle: 'tags',
+        path:   'topics'
+      }))
+      .use(function(files, metalsmith, done) {
+        tagList = metalsmith.data.tags;
+        done();
+      })
+      .build(function(err, files){
+        if (err) return done(err);
+        assert.deepEqual(Object.keys(tagList).sort(), ['hello', 'tag', 'this', 'this-is', 'world']);
+        done();
+      });
+  });
+
   it('should create tag page with post lists according to template and sorted by date decreasing', function(done){
     Metalsmith('test/fixtures')
       .use(tags({


### PR DESCRIPTION
There are times when templates might want access to the tags data and not be
one of the tag output files. Currently the tags data is only available in the
output file (`topics/{tag}.html`) for which your template can iterate over the
tags object.

With this feature the user can iterate over tags outside of the output file by
accessing the `metalsmith.data.tags` property (or in the case of a template
`this.tags`).
