### PR TITLE
Fix tag list and tests so they work with Metalsmith 1.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,16 +51,15 @@ function plugin(opts) {
     }
 
     // Add to metalsmith.data for access outside of the tag files.
-    if (!metalsmith.data.tags) {
-      metalsmith.data.tags = {};
-    }
+    var metadata = metalsmith.metadata();
+    metadata.tags = metadata.tags || {};
 
     for (var tag in tagList) {
         var posts = tagList[tag].sort(sortBy);
         if ( opts.reverse ) {
           posts.reverse();
         }
-        metalsmith.data.tags[tag] = posts;
+        metadata.tags[tag] = posts;
         files[opts.path + '/' + tag + '.html'] = {
                template: opts.template,
                mode: '0644',
@@ -69,6 +68,10 @@ function plugin(opts) {
                posts: posts
         };
     }
+
+    // update metadata
+    metalsmith.metadata(metadata);
+
     done();
   };
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "assert-dir-equal": "0.0.1",
     "handlebars": "*",
-    "metalsmith": "0.x",
-    "metalsmith-templates": "~0.5.2",
+    "metalsmith": "1.x",
+    "metalsmith-templates": "~0.6.0",
     "mocha": "1.x",
     "moment": "^2.7.0"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,7 @@ describe('metalsmith-tags', function(){
       });
   });
 
-  it('should create a tags property to metalsmith.data', function(done) {
+  it('should create a tags property to metalsmith.metadata', function(done) {
     var tagList;
 
     Metalsmith('test/fixtures')
@@ -35,7 +35,7 @@ describe('metalsmith-tags', function(){
         path:   'topics'
       }))
       .use(function(files, metalsmith, done) {
-        tagList = metalsmith.data.tags;
+        tagList = metalsmith.metadata().tags;
         done();
       })
       .build(function(err, files){
@@ -49,8 +49,8 @@ describe('metalsmith-tags', function(){
     Metalsmith('test/fixtures')
       .use(tags({
         handle: 'tags',
-        path:'topics',
-        template:'/../tag.hbt',
+        path: 'topics',
+        template: './../tag.hbt',
         sortBy: 'date',
         reverse: true
       }))
@@ -61,5 +61,4 @@ describe('metalsmith-tags', function(){
         done();
       });
   });
-
 });


### PR DESCRIPTION
- Used `metalsmith.metadata()` to store the tag list, since `metalsmith.data` does not currently exist on `1.x` versions of Metalsmith.
- Updated `metalsmith-templates` version in `package.json` so tests pass.