### PR TITLE
Use configuration option for global metadata key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can use different handle for the tags, by configuring the `handle` option. `
 }
 ```
 
-## Javascript Usage
+## JavaScript Usage
 
   Pass the plugin to `Metalsmith#use`:
 
@@ -65,6 +65,8 @@ metalsmith
 
   You can use `metalsmith-permalink` to customize the permalink of the tag pages as you would do with anything else.
 
+  It is possible to use `opts.metadataKey` for defining the name of the global tag list.
+  By default it is `'tags'`.
 
 ## Pagination
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ function plugin(opts) {
   opts.pathPage = opts.pathPage || 'tags/:tag/:num/index.html';
   opts.template = opts.template || 'partials/tag.hbt';
   opts.handle = opts.handle || 'tags';
-  opts.global = opts.global || 'alltags';
+  opts.metadataKey = opts.metadataKey || 'tags';
   opts.sortBy = opts.sortBy || 'title';
   opts.reverse = opts.reverse || false;
   opts.perPage  = opts.perPage || 0;
@@ -75,7 +75,7 @@ function plugin(opts) {
 
     // Add to metalsmith.metadata for access outside of the tag files.
     var metadata = metalsmith.metadata();
-    metadata[opts.global] = metadata[opts.global] || {};
+    metadata[opts.metadataKey] = metadata[opts.metadataKey] || {};
 
     Object.keys(tagList).forEach(function(tag) {
       // Sort tags via opts.sortBy property value.
@@ -86,7 +86,7 @@ function plugin(opts) {
         posts.reverse();
       }
 
-      metadata[opts.global][tag] = posts;
+      metadata[opts.metadataKey][tag] = posts;
 
       // If we set opts.perPage to 0 then we don't want to paginate and as such
       // we should have all posts shown on one page.

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ function plugin(opts) {
   opts.pathPage = opts.pathPage || 'tags/:tag/:num/index.html';
   opts.template = opts.template || 'partials/tag.hbt';
   opts.handle = opts.handle || 'tags';
+  opts.global = opts.global || 'alltags';
   opts.sortBy = opts.sortBy || 'title';
   opts.reverse = opts.reverse || false;
   opts.perPage  = opts.perPage || 0;
@@ -74,7 +75,7 @@ function plugin(opts) {
 
     // Add to metalsmith.metadata for access outside of the tag files.
     var metadata = metalsmith.metadata();
-    metadata.tags = metadata.tags || {};
+    metadata[opts.global] = metadata[opts.global] || {};
 
     Object.keys(tagList).forEach(function(tag) {
       // Sort tags via opts.sortBy property value.
@@ -85,7 +86,7 @@ function plugin(opts) {
         posts.reverse();
       }
 
-      metadata.tags[tag] = posts;
+      metadata[opts.global][tag] = posts;
 
       // If we set opts.perPage to 0 then we don't want to paginate and as such
       // we should have all posts shown on one page.
@@ -126,7 +127,6 @@ function plugin(opts) {
         pages.push(page);
       }
     });
-
 
     // update metadata
     metalsmith.metadata(metadata);


### PR DESCRIPTION
Instead of having the local `handle` and global metadata key to be the same, allow to configure the global handle name.

It could be configured:

```json
    "metalsmith-tags": {
      "handle": "tags",
      "global": "alltags",
      "path": "tag-:tag.html",
      "template": "listing.html",
      "sortBy": "publishtime",
      "reverse": true
    }
```

and used in a template as such:

```swig
 <ul class="tags">
  {% for tag in alltags|sort %}
    <li><a href="/tag-{{ tag }}" title="{{ tag }}">{{ tag }}</a></li>
  {% endfor %}
  </ul>
```

This would allow to have a list of all the tags as `alltags` and the tags for the given page as `tags`.