### PR TITLE
Store map of post indices rather than duplicate posts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,37 +64,44 @@ function plugin(opts) {
     }
 
     // Find all tags and their associated files.
-    Object.keys(files).forEach(function(file) {
-      var data = files[file];
-      var tagsData = data[opts.handle];
+    for (var index in files) {
+      var data = files[index];
 
-      // If we have tag data for this file then turn it into an array of
-      // individual tags where each tag has been sanitized.
-      if (tagsData) {
-        if (typeof tagsData === 'string') {
-          tagsData = tagsData.split(',');
-        }
+      if (data) {
+        var tagsData = data[opts.handle];
 
-        // Save formatted tags data.
-        // Trims leading + trailing white space from tag.
-        data[opts.handle] = tagsData.map(function(tag) {
-          return String(tag).trim();
-        });
-
-        // Add each tag to our overall tagList.
-        data[opts.handle].forEach(function(tag) {
-          // Initialize array if it doesn't exist.
-          if (!tagList[tag]) {
-            tagList[tag] = [];
+        // If we have tag data for this file then turn it into an array of
+        // individual tags where each tag has been sanitized.
+        if (tagsData) {
+          if (typeof tagsData === 'string') {
+            tagsData = tagsData.split(',');
           }
 
-          tagList[tag].push(data);
-        });
+          // Save formatted tags data.
+          // Trims leading + trailing white space from tag.
+          data[opts.handle] = tagsData.map(function(tag) {
+            return String(tag).trim();
+          });
+
+          var handle = data[opts.handle];
+
+          // Add each tag to our overall tagList.
+          for (var j = 0, tag = handle[0]; j < handle.length; j++) {
+
+            if (!tagList[tag]) {
+              tagList[tag] = [];
+            }
+
+            tagList[tag].push(index);
+            tag = handle[j];
+          }
+        }
       }
-    });
+    }
 
     // Add to metalsmith.metadata for access outside of the tag files.
     var metadata = metalsmith.metadata();
+
     metadata[opts.metadataKey] = metadata[opts.metadataKey] || {};
 
     Object.keys(tagList).forEach(function(tag) {
@@ -116,6 +123,10 @@ function plugin(opts) {
 
       for (var i = 0; i < numPages; i++) {
         var pageFiles = posts.slice(i * postsPerPage, (i + 1) * postsPerPage);
+
+        for (var j = pageFiles.length - 1; j >= 0; j--) {
+          pageFiles[j] = files[pageFiles[j]]
+        };
 
         // Generate a new file based on the filename with correct metadata.
         var page = {


### PR DESCRIPTION
This is a fix for using metalsmith-tags with a large number of posts or complex call chain where it runs slow or hangs #17. For my own blog of several hundred entries of markdown and my chain, the plugin just hangs indefinitely.

Console logging through everything I've reduced this down to line 91, which duplicates the whole post/all posts and can cause the maximum size of the call chain to be exceeded, without returning an error. 

I've managed to modify my own version of metalsmith-tags to instead copy the indices of posts to later retrieve them, which seems to completely remove the problem.