### PR TITLE
Updates to use metalsmith-layouts instead of metalsmith-templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can use different handle for the tags, by configuring the `handle` option. `
     "metalsmith-tags": {
       "handle": "tags",
       "path": "topics/:tag.html",
-      "template": "/partials/tag.hbt",
+      "layout": "/partials/tag.hbt",
       "sortBy": "date",
       "reverse": true,
       "skipMetadata": false
@@ -54,8 +54,8 @@ metalsmith
     handle: 'tags',
     // path for result pages
     path:'topics/:tag.html',
-    // template to use for tag listing
-    template:'/partials/tag.hbt',
+    // layout to use for tag listing
+    layout:'/partials/tag.hbt',
     // provide posts sorted by 'date' (optional)
     sortBy: 'date',
     // sort direction (optional)
@@ -69,7 +69,7 @@ metalsmith
 
 ## Result
 
-  This will generate `topics/[tagname].html` pages in your `build` directory with array of `pagination.files` objects on which you can iterate on. You can use `tag` for tag name in your templates. (You can refer to tests folder for tags template.)
+  This will generate `topics/[tagname].html` pages in your `build` directory with array of `pagination.files` objects on which you can iterate on. You can use `tag` for tag name in your layouts. (You can refer to tests folder for tags layout.)
 
   The `tags` property on your pages will remain but it will be modified to an array of String containing the tags.
 
@@ -88,7 +88,7 @@ metalsmith
   "path": "topics/:tag/index.html",
   "pathPage": "topics/:tag/:num/index.html",
   "perPage": 6,
-  "template": "/partials/tag.hbt",
+  "layout": "/partials/tag.hbt",
   "sortBy": "date",
   "reverse": true,
   "skipMetadata": false

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ function plugin(opts) {
   opts = opts || {};
   opts.path = opts.path || 'tags/:tag/index.html';
   opts.pathPage = opts.pathPage || 'tags/:tag/:num/index.html';
-  opts.template = opts.template || 'partials/tag.hbt';
+  opts.layout = opts.layout || 'partials/tag.hbt';
   opts.handle = opts.handle || 'tags';
   opts.metadataKey = opts.metadataKey || 'tags';
   opts.sortBy = opts.sortBy || 'title';
@@ -135,7 +135,7 @@ function plugin(opts) {
 
         // Generate a new file based on the filename with correct metadata.
         var page = {
-          template: opts.template,
+          layout: opts.layout,
           contents: '',
           tag: tag,
           pagination: {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "assert-dir-equal": "1.0.1",
     "handlebars": "*",
     "metalsmith": "1.x",
-    "metalsmith-templates": "~0.7.0",
+    "metalsmith-layouts": "1.x",
     "mocha": "2.x",
     "moment": "^2.10.3"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var equal = require('assert-dir-equal');
 var Metalsmith = require('metalsmith');
-var templates = require('metalsmith-templates');
+var layouts = require('metalsmith-layouts');
 var tags = require('../lib');
 var Handlebars = require('handlebars');
 var moment = require('moment');
@@ -78,7 +78,8 @@ describe('metalsmith-tags', function() {
 
   var templateConfig = {
     engine: 'handlebars',
-    directory: './'
+    directory: './',
+    pattern: "topics/**/*.html"
   };
 
   it('should create tag page with post lists according to template and sorted by date decreasing', function(done) {
@@ -86,11 +87,11 @@ describe('metalsmith-tags', function() {
       .use(tags({
         handle: 'tags',
         path: 'topics/:tag.html',
-        template: './tag.hbt',
+        layout: './tag.hbt',
         sortBy: 'date',
         reverse: true
       }))
-      .use(templates(templateConfig))
+      .use(layouts(templateConfig))
       .build(function(err){
         if (err) return done(err);
         equal('test/fixtures/expected/no-pagination/topics', 'test/fixtures/build/topics');
@@ -105,11 +106,11 @@ describe('metalsmith-tags', function() {
         path: 'topics/:tag/index.html',
         pathPage: 'topics/:tag/:num/index.html',
         perPage: 1,
-        template: './tag.hbt',
+        layout: './tag.hbt',
         sortBy: 'date',
         reverse: true
       }))
-      .use(templates(templateConfig))
+      .use(layouts(templateConfig))
       .build(function(err){
         if (err) return done(err);
         equal('test/fixtures/expected/pagination/topics', 'test/fixtures/build/topics');


### PR DESCRIPTION
As discussed in #20 `metalsmith-templates` is deprecated, I've used a couple workarounds to support `metalsmith-layouts`. This fork makes changes that replaces templates with layouts throughout and has updated tests that work with the same test data as previous.