### PR TITLE
Add path to pages in pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Test Fixture build results
 test/fixtures/build/*
+
+# JetBrains project files
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,10 +162,11 @@ function plugin(opts) {
 
         // Render the non-first pages differently to the rest, when set.
         if (i > 0 && opts.pathPage) {
-          files[getFilePath(opts.pathPage, page.pagination)] = page;
+          page.path = getFilePath(opts.pathPage, page.pagination);
         } else {
-          files[getFilePath(opts.path, page.pagination)] = page;
+          page.path = getFilePath(opts.path, page.pagination);
         }
+        files[page.path] = page;
 
         // Update next/prev references.
         var previousPage = pages[i - 1];

--- a/test/fixtures/expected/pagination/topics/hello/2/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/2/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
 	<li><small>07/01/2014</small> test json</li>
-</ul>
+</ul><a href="topics/hello/index.html">Previous</a><a href="topics/hello/3/index.html">Next</a>

--- a/test/fixtures/expected/pagination/topics/hello/3/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/3/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
 	<li><small>02/03/2014</small> test</li>
-</ul>
+</ul><a href="topics/hello/2/index.html">Previous</a><a href="topics/hello/4/index.html">Next</a>

--- a/test/fixtures/expected/pagination/topics/hello/4/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/4/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
 	<li><small>02/02/2014</small> about</li>
-</ul>
+</ul><a href="topics/hello/3/index.html">Previous</a>

--- a/test/fixtures/expected/pagination/topics/hello/index.html
+++ b/test/fixtures/expected/pagination/topics/hello/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for hello</h1>
 <ul>
 	<li><small>07/02/2014</small> test page 2</li>
-</ul>
+</ul><a href="topics/hello/2/index.html">Next</a>

--- a/test/fixtures/expected/pagination/topics/tag/2/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/2/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for tag</h1>
 <ul>
 	<li><small>07/01/2014</small> test json</li>
-</ul>
+</ul><a href="topics/tag/index.html">Previous</a><a href="topics/tag/3/index.html">Next</a>

--- a/test/fixtures/expected/pagination/topics/tag/3/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/3/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for tag</h1>
 <ul>
 	<li><small>02/03/2014</small> test</li>
-</ul>
+</ul><a href="topics/tag/2/index.html">Previous</a>

--- a/test/fixtures/expected/pagination/topics/tag/index.html
+++ b/test/fixtures/expected/pagination/topics/tag/index.html
@@ -1,4 +1,4 @@
 <h1>Posts for tag</h1>
 <ul>
 	<li><small>07/02/2014</small> test page 2</li>
-</ul>
+</ul><a href="topics/tag/2/index.html">Next</a>

--- a/test/fixtures/tag.hbt
+++ b/test/fixtures/tag.hbt
@@ -1,4 +1,4 @@
 <h1>Posts for {{tag}}</h1>
 <ul>{{#each pagination.files}}
 	<li><small>{{dateFormat date "DD/MM/YYYY"}}</small> {{title}}</li>
-{{/each}}</ul>
+{{/each}}</ul>{{#if pagination.previous}}<a href="{{pagination.previous.path}}">Previous</a>{{/if}}{{#if pagination.next}}<a href="{{pagination.next.path}}">Next</a>{{/if}}


### PR DESCRIPTION
I found that this metalsmith plugin was not compatible with the [metalsmith-pagination](https://github.com/blakeembrey/metalsmith-pagination) plugin as far as `page.path` was concerned. I added the functionality so that users of metalsmith-pagination can use this without changing their templates. Tests have been updated accordingly.