### PR TITLE
use 'slug' to create really url-safe category slugs; expose slug's options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+
+var slug = require('slug');
+
 /**
  * A metalsmith plugin to create dedicated pages for tags in posts or pages.
  *
@@ -21,6 +24,7 @@ function plugin(opts) {
   opts.reverse = opts.reverse || false;
   opts.perPage  = opts.perPage || 0;
   opts.skipMetadata = opts.skipMetadata || false;
+  opts.slug = opts.slug || {mode: 'rfc3986'};
 
   return function(files, metalsmith, done) {
     /**
@@ -29,7 +33,7 @@ function plugin(opts) {
      * @return {string} safe tag
      */
     function safeTag(tag) {
-      return tag.replace(/ /g, '-');
+      return opts.slug === false ? tag.replace(/ /g, '-') : slug(tag, opts.slug);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "metalsmith-layouts": "1.x",
     "mocha": "2.x",
     "moment": "^2.10.3"
+  },
+  "dependencies": {
+    "slug": "^0.9.1"
   }
 }


### PR DESCRIPTION
Like the title already says...

This enables the usage of special characters in tag names, which will be replaced when a url is generated from that tag name.

For example: "Motörhead" becomes "motorhead"

