### PR TITLE
Support slug options for metadata urlSafe tags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,7 +137,7 @@ function plugin(opts) {
 
       if (!opts.skipMetadata) {
         metadata[opts.metadataKey][tag] = posts;
-        metadata[opts.metadataKey][tag].urlSafe = slug(tag);
+        metadata[opts.metadataKey][tag].urlSafe = safeTag(tag);
       }
 
       // If we set opts.perPage to 0 then we don't want to paginate and as such


### PR DESCRIPTION
This makes the urlSafe tags in site metadata consistent with the urlSafe tags in individual posts.