### PR TITLE
Add support for a custom slug function option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ metalsmith
     // (optional)
     skipMetadata: false,
     // Any options you want to pass to the [slug](https://github.com/dodo/node-slug) package.
+    // Can also supply a custom slug function.
+    // slug: function(tag) { return tag.toLowerCase() }
     slug: {mode: 'rfc3986'}
   }));
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,10 @@ function plugin(opts) {
      * @return {string} safe tag
      */
     function safeTag(tag) {
+      if (typeof opts.slug === 'function') {
+        return opts.slug(tag);
+      }
+
       return slug(tag, opts.slug);
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -146,4 +146,21 @@ describe('metalsmith-tags', function() {
         done();
       });
   });
+
+  it('should support custom slug functions', function(done) {
+    Metalsmith('test/fixtures')
+      .use(tags({
+        handle: 'tags',
+        path: 'topics',
+        slug: function(tag) {
+          return tag.toUpperCase();
+        }
+      }))
+      .build(function(err, files) {
+        if (err) return done(err);
+        assert.equal(files['index.html'].tags.toString(),['hello', 'world', 'this is', 'tag'].toString());
+        assert.equal(files['index.html'].tagsUrlSafe.toString(),['HELLO', 'WORLD', 'THIS IS', 'TAG'].toString());
+        done();
+      });
+  })
 });


### PR DESCRIPTION
I have a site that *almost* uses node-slug-compatible slugs for tags, but has a couple of exceptions. Rewriting the slugs after metalsmith-tags is done with 'em isn't very clean, because it requires updating `tagsUrlSafe` on every file as well.