### PR TITLE
Clearing tagList to support multiple invocations of plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,12 @@ function plugin(opts) {
       metalsmith.metadata(metadata);
     }
 
+    /* clearing this after each pass avoids
+     * double counting when using metalsmith-watch
+     */
+    tagList = {};
     done();
+
   };
 }
 


### PR DESCRIPTION
Just a small change that allows for use of this plugin in conjunction with metalsmith-watch. In the absence of this one-liner, the tag collections grow with each edit of files or style.

The motivating issue is not a show-stopper since it can be avoided with a fresh build cleans up the lists, but it's a minor annoyance while making multiple edits to the site.