### PR TITLE
Add a tagsCollection object holding a display & url safe tag label

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ metalsmith
 
   There will also be a `tagsUrlSafe` array created that will contain an array of url safe tag names for use in url creation.
 
+  There will also be a `tagsCollection` array created that will have an object containing the `urlSlug` and `display` properties of each tag.
+
   You can use `metalsmith-permalink` to customize the permalink of the tag pages as you would do with anything else.
 
   It is possible to use `opts.metadataKey` for defining the name of the global tag list.

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ function plugin(opts) {
   opts.layout = opts.layout || 'partials/tag.hbt';
   opts.handle = opts.handle || 'tags';
   var handleUrlSafe = opts.handle + 'UrlSafe';
+  var handleCollection = opts.handle + 'Collection';
   opts.metadataKey = opts.metadataKey || 'tags';
   opts.sortBy = opts.sortBy || 'title';
   opts.reverse = opts.reverse || false;
@@ -98,6 +99,10 @@ function plugin(opts) {
         // Add url safe version of every tag as well.
         data[handleUrlSafe] = [];
 
+        // Add an object containing the display and
+        // safe url version of every tag
+        data[handleCollection] = [];
+
         tagsData.forEach(function(rawTag) {
           // Trim leading + trailing white space from tag.
           var tag = String(rawTag).trim();
@@ -107,6 +112,9 @@ function plugin(opts) {
 
           // Save url safe formatted tag data.
           data[handleUrlSafe].push(safeTag(tag));
+
+          // Save url safe formatted and display versions of tag data
+          data[handleCollection].push({ display: tag, urlSlug: safeTag(tag)});
 
           // Add each tag to our overall tagList and initialize array if it
           // doesn't exist.

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ describe('metalsmith-tags', function() {
         if (err) return done(err);
         assert.equal(files['index.html'].tags.toString(),['hello', 'world', 'this is', 'tag'].toString());
         assert.equal(files['index.html'].tagsUrlSafe.toString(),['hello', 'world', 'this-is', 'tag'].toString());
+        assert.equal(files['index.html'].tagsCollection.toString(),[{ display: 'hello', urlSlug: 'hello'}, { display: 'world', urlSlug: 'world'}, { display: 'this is', urlSlug: 'this-is'}, { display: 'tag', urlSlug: 'tag'}].toString());
         done();
       });
   });


### PR DESCRIPTION
There are times when I want to display a list of tags that link to their respective index. Currently, the `tags` and `tagsUrlSafe` arrays are separate. This `tagsCollection` array allows us to do something like the following:

```
{{#each tagsCollection as |tag| }}
    <a href="/articles/tags/{{tag.urlSlug}}">{{tag.display}}</a>
{{/each}}
```

Rather than commit a breaking change I figured it made sense to just add an additional property to the metadata.