### PR TITLE
Merge v1.2.1 tag into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-tags",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A metalsmith plugin to create dedicated pages for tags in posts or pages.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Looks like tag `v1.2.1` has not been merged into master, but v1.2.1 has been published on npm.