### PR TITLE
Combine tagsUrlSafe and tagsCollection into one property

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,7 @@ metalsmith
 
   This will generate `topics/[tagname].html` pages in your `build` directory with array of `pagination.files` objects on which you can iterate on. You can use `tag` for tag name in your layouts. (You can refer to tests folder for tags layout.)
 
-  The `tags` property on your pages will remain but it will be modified to an array of String containing the tags.
-
-  There will also be a `tagsUrlSafe` array created that will contain an array of url safe tag names for use in url creation.
-
-  There will also be a `tagsCollection` array created that will have an object containing the `urlSlug` and `display` properties of each tag.
+  The `tags` property on your pages will remain, but it will be modified to an array of objects containing a `name` and `slug` property for each tag.
 
   You can use `metalsmith-permalink` to customize the permalink of the tag pages as you would do with anything else.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-
 var slug = require('slug');
 
 /**
@@ -18,8 +17,6 @@ function plugin(opts) {
   opts.pathPage = opts.pathPage || 'tags/:tag/:num/index.html';
   opts.layout = opts.layout || 'partials/tag.hbt';
   opts.handle = opts.handle || 'tags';
-  var handleUrlSafe = opts.handle + 'UrlSafe';
-  var handleCollection = opts.handle + 'Collection';
   opts.metadataKey = opts.metadataKey || 'tags';
   opts.sortBy = opts.sortBy || 'title';
   opts.reverse = opts.reverse || false;
@@ -96,25 +93,13 @@ function plugin(opts) {
         // Re-initialize tag array.
         data[opts.handle] = [];
 
-        // Add url safe version of every tag as well.
-        data[handleUrlSafe] = [];
-
-        // Add an object containing the display and
-        // safe url version of every tag
-        data[handleCollection] = [];
-
         tagsData.forEach(function(rawTag) {
           // Trim leading + trailing white space from tag.
           var tag = String(rawTag).trim();
 
-          // Save formatted tag data.
-          data[opts.handle].push(tag);
-
-          // Save url safe formatted tag data.
-          data[handleUrlSafe].push(safeTag(tag));
 
           // Save url safe formatted and display versions of tag data
-          data[handleCollection].push({ display: tag, urlSlug: safeTag(tag)});
+          data[opts.handle].push({ name: tag, slug: safeTag(tag)});
 
           // Add each tag to our overall tagList and initialize array if it
           // doesn't exist.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-tags",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A metalsmith plugin to create dedicated pages for tags in posts or pages.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-tags",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A metalsmith plugin to create dedicated pages for tags in posts or pages.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -22,9 +22,7 @@ describe('metalsmith-tags', function() {
       }))
       .build(function(err,files){
         if (err) return done(err);
-        assert.equal(files['index.html'].tags.toString(),['hello', 'world', 'this is', 'tag'].toString());
-        assert.equal(files['index.html'].tagsUrlSafe.toString(),['hello', 'world', 'this-is', 'tag'].toString());
-        assert.equal(files['index.html'].tagsCollection.toString(),[{ display: 'hello', urlSlug: 'hello'}, { display: 'world', urlSlug: 'world'}, { display: 'this is', urlSlug: 'this-is'}, { display: 'tag', urlSlug: 'tag'}].toString());
+        assert.equal(files['index.html'].tags.toString(),[{ name: 'hello', slug: 'hello'}, { name: 'world', slug: 'world'}, { name: 'this is', slug: 'this-is'}, { name: 'tag', slug: 'tag'}].toString());
         done();
       });
   });
@@ -159,8 +157,7 @@ describe('metalsmith-tags', function() {
       }))
       .build(function(err, files) {
         if (err) return done(err);
-        assert.equal(files['index.html'].tags.toString(),['hello', 'world', 'this is', 'tag'].toString());
-        assert.equal(files['index.html'].tagsUrlSafe.toString(),['HELLO', 'WORLD', 'THIS IS', 'TAG'].toString());
+        assert.equal(files['index.html'].tags.toString(),[{ name: 'hello', slug: 'HELLO'}, { name: 'world', slug: 'WORLD'}, { name: 'this is', slug: 'THIS IS'}, { name: 'tag', slug: 'TAG'}].toString());
         done();
       });
   })


### PR DESCRIPTION
This commit combines the `tagsCollection` and `tagsUrlSafe` properties into one property, named by the  plugin option `handle`, or "tags" by default.

The `tags` property will now return an array containing an object with a `name` and `slug` property that can be used like so:

```
{{#each tags as |tag| }}
  <a href="{{tag.slug}}">{{tag.name}}</a>
{{/each}}
```

As discussed in #34, this would be a breaking change, that would be held onto until the next major release.