### PR TITLE
added count property to global tags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,7 @@ function plugin(opts) {
       if (!opts.skipMetadata) {
         metadata[opts.metadataKey][tag] = posts;
         metadata[opts.metadataKey][tag].urlSafe = safeTag(tag);
+        metadata[opts.metadataKey][tag].count = posts.length;
       }
 
       // If we set opts.perPage to 0 then we don't want to paginate and as such


### PR DESCRIPTION
Adds a `count` property to global tags, so it's easier to make tag lists like:
- debian (6 posts)
- node (3 posts)
