### PR TITLE
Remove odd metadata reassign

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,11 +183,6 @@ function plugin(opts) {
       }
     }
 
-    // update metadata
-    if (!opts.skipMetadata) {
-      metalsmith.metadata(metadata);
-    }
-
     /* clearing this after each pass avoids
      * double counting when using metalsmith-watch
      */


### PR DESCRIPTION
We do not need to reassign metalsmith metadata, because of metalsmith return its internal metadata object. So if something changed in this metadata object its changed for all next plugin.

But when we reassign metalsmith metadata with `metadata(<new metadata>)` function this `<new metadata>` clones with deep copying. And this deep copying breaks the consistency of previously created referencing (for example by `metalsmith-collections` plugin) from some metadata property to files objects. And if next plugins change something in files, this change will not reflect in metadata, because of metadata property reference to copied files objects.