### PR TITLE
Handle tags that are already in an array of objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,12 @@ function plugin(opts) {
 
         tagsData.forEach(function(rawTag) {
           // Trim leading + trailing white space from tag.
-          var tag = String(rawTag).trim();
+          var tag = ''
+          if (typeof rawTag === 'object') {
+            tag = String(rawTag.name).trim();
+          } else {
+            tag = String(rawTag).trim();
+          }
 
 
           // Save url safe formatted and display versions of tag data


### PR DESCRIPTION
If the tags key already contains an array of tag-objects, this plugin
breaks down. This commit changes this behavior by checking if a tag is
an object. If it is, it assumes that the 'name' key holds the tag name.
(following the naming convention of the plugin)

I needed this for a project where metalsmith files are effectively reprocessed, 
so I thought I just as well might share it with the community.